### PR TITLE
fix(Navigation): Make navigation clickable on mobile

### DIFF
--- a/src/ui/components/Logo/index.js
+++ b/src/ui/components/Logo/index.js
@@ -23,7 +23,7 @@ const Logo = styled.h1`
       null,
       props.theme.smSpacing
     )};
-  z-index: 200;
+  z-index: 1;
   height: 30px;
   transition: top 0.32s ease-in-out, color 0.32s ease-in-out,
     opacity 0.16s ease-in-out;

--- a/src/ui/components/Navigation/index.js
+++ b/src/ui/components/Navigation/index.js
@@ -9,6 +9,7 @@ import Link from './Link'
 
 const Navigation = styled.nav`
   ${position('absolute', '-30px', null, null, '0')};
+  z-index: 2;
   transition: top 0.32s ease-in-out, opacity 0.32s ease-in-out;
   opacity: 0;
   text-align: left;


### PR DESCRIPTION
Before the logo had a higher z-index then the Navigation component. On desktop this didn't matter
since the Logo component and the Navigation component didn't overlap each other. On mobile they did.
By giving the Navigation component a higher z-index and decreasing the z-index of the Logo component
this is solved

fix #1